### PR TITLE
Fix typo in benchmark result file discovered by codespell

### DIFF
--- a/benchmarks/benchmark_result.txt
+++ b/benchmarks/benchmark_result.txt
@@ -1,4 +1,4 @@
-Runtime Infomation
+Runtime Information
 OS: macOS 11.3.1 20E241 arm64
 Host: MacBookAir10,1
 


### PR DESCRIPTION
Fix typo discovered by codespell - https://pypi.org/project/codespell

% `codespell`
```
benchmarks/benchmark_result.txt:1: Infomation ==> Information
```
% `codespell --write-changes` 