### PR TITLE
ci: build free-threaded manylinux x86_64 wheel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,23 @@ jobs:
           name: wheels-musllinux-${{ matrix.platform.target }}
           path: dist
 
+  linux-free-threaded:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v6
+      - name: Build Python 3.14t manylinux x86_64 wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          target: x86_64
+          args: --release --out dist -i python3.14t
+          sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
+          manylinux: 2014
+      - name: Upload wheels
+        uses: actions/upload-artifact@v7
+        with:
+          name: wheels-linux-free-threaded-x86_64
+          path: dist
+
   windows:
     runs-on: ${{ matrix.platform.runner }}
     strategy:
@@ -180,7 +197,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     if: ${{ startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' }}
-    needs: [linux, musllinux, windows, macos, sdist, tests]
+    needs: [linux, linux-free-threaded, musllinux, windows, macos, sdist, tests]
     permissions:
       # Use to sign the release artifacts
       id-token: write


### PR DESCRIPTION
This adds an explicit Linux x86_64 free-threaded wheel build for Python 3.14t.

The v0.3.6 release artifacts include the regular CPython 3.14 manylinux x86_64 wheel, but not the free-threaded one:

- present: fastcrc-0.3.6-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
- missing: fastcrc-0.3.6-cp314-cp314t-*-x86_64.whl for glibc/manylinux

There is a cp314t x86_64 musllinux wheel, and other Linux architectures already have cp314t manylinux wheels. The missing artifact appears to be limited to the glibc x86_64 free-threaded wheel.

The new job keeps the existing manylinux2014 compatibility baseline and adds a dedicated Python 3.14t x86_64 build using:

- manylinux: 2014
- args: --release --out dist -i python3.14t

The release job now depends on this new artifact so tag releases can publish it together with the existing wheels.

Validation performed locally:

- inspected the v0.3.6 wheels-linux-x86_64 artifact from GitHub Actions; it contains cp314-cp314 but no cp314-cp314t wheel
- verified quay.io/pypa/manylinux2014_x86_64 currently contains both cp314-cp314 and cp314-cp314t under /opt/python
- built fastcrc 0.3.6 locally for /opt/python314t as fastcrc-0.3.6-cp314-cp314t-manylinux_2_34_x86_64.whl and imported it successfully in a free-threaded Python 3.14t runtime

This PR is intentionally kept as a draft until CI confirms the additional manylinux2014 job produces the expected cp314-cp314t x86_64 wheel.